### PR TITLE
Fix Mezo Passport URL

### DIFF
--- a/src/content/docs/docs/developers/index.mdx
+++ b/src/content/docs/docs/developers/index.mdx
@@ -11,7 +11,7 @@ Configure your environment and deploy an example dApp enabled with Mezo Passport
 
 <LinkButton href="/docs/developers/getting-started/configure-environment">Configure Your Development Environment</LinkButton>
 
-<LinkButton href="/docs/developers/getting-started/configure-passport" variant="secondary">Add Mezo Passport to your dApp</LinkButton>
+<LinkButton href="/docs/developers/getting-started/configure-mezo-passport" variant="secondary">Add Mezo Passport to your dApp</LinkButton>
 
 ## Users
 


### PR DESCRIPTION
This fixes the URL set on the developers page. from `configure-passport` to the correct `configure-mezo-passport`