### PR TITLE
Title change to make it clear it's MUSD bridge

### DIFF
--- a/src/content/docs/docs/users/bridge/musd-bridge.md
+++ b/src/content/docs/docs/users/bridge/musd-bridge.md
@@ -1,5 +1,5 @@
 ---
-title: Bridge
+title: MUSD Bridge
 description: >-
   Learn how to bridge MUSD tokens between Ethereum and Mezo using Wormhole's
   Native Token Transfer protocol.


### PR DESCRIPTION
We have multiple sections for bridges in our docs. As a low hanging fruit we can improve navigation stating that Bridge > Bridge actually covers only MUSD bridge

<img width="345" height="510" alt="Screenshot 2025-08-22 at 13 34 49" src="https://github.com/user-attachments/assets/b4918678-4060-4765-a196-7f04131949f3" />
