### PR TITLE
Make mats.md page hidden from navigation and search

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -97,7 +97,7 @@ export default defineConfig({
                         label: 'Getting Started',
                         collapsed: true,
                         items: [
-                              'docs/users/getting-started/bridging',
+                              'docs/users/getting-started/deposit-assets',
                               'docs/users/getting-started/connect',
                               'docs/users/getting-started/creating-an-account'
                         ]
@@ -114,8 +114,7 @@ export default defineConfig({
                         label: 'Mainnet',
                         collapsed: true,
                         items: [
-                              'docs/users/mainnet/bridges',
-                              'docs/users/mainnet/mats'
+                              'docs/users/mainnet/bridges'
                         ]
                   },
                   {
@@ -126,8 +125,8 @@ export default defineConfig({
                               'docs/users/musd/concepts',
                               'docs/users/musd/fees',
                               'docs/users/musd',
-                              'docs/users/musd/liquidation-mechanics',
                               'docs/users/musd/mint-musd',
+                              'docs/users/musd/liquidation-mechanics',
                               'docs/users/musd/musd-bridge',
                               'docs/users/musd/risks'
                         ]

--- a/src/content/docs/docs/users/mainnet/mats.md
+++ b/src/content/docs/docs/users/mainnet/mats.md
@@ -2,6 +2,7 @@
 title: Mainnet mats Guide
 description: What mats are and how they work.
 topic: users
+hidden: true
 ---
 
 mats, or "magic satoshis," are Mezo's way of recognizing and rewarding participation through an engaging, community-driven point system.

--- a/src/content/docs/docs/users/musd/liquidation-mechanics.md
+++ b/src/content/docs/docs/users/musd/liquidation-mechanics.md
@@ -1,6 +1,9 @@
 ---
 title: MUSD Liquidations & Redemptions
-description: Learn how liquidations protect the system and how redemptions maintain the MUSD peg.
+description: >-
+  Learn how liquidations protect the system and how redemptions maintain the
+  MUSD peg.
+topic: users
 ---
 
 ## Liquidations


### PR DESCRIPTION
- Keep 'hidden: true' in mats.md frontmatter
- Remove mats.md from sidebar configuration
- Page remains accessible via direct URL but hidden from navigation and search
- Ensures mats page is not discoverable through normal site navigation

Going to undo this PR when we update the mats content 