### PR TITLE
Changing outdated testnet MUSD address to a current one

### DIFF
--- a/src/content/docs/docs/users/musd/index.md
+++ b/src/content/docs/docs/users/musd/index.md
@@ -17,7 +17,7 @@ You must deposit a minimum of \$1800 US worth of BTC or other supported tokens a
 On Mezo, MUSD and Borrow provide solutions to several lending market challenges:
 
 * Permissionless access to a credit against up to 90% of your BTC holdings. Keep your BTC, tap into your Bitcoin equity, and pay your loan back whenever.
-* Loans are created onchain and [publicly verifiable 24/7](https://explorer.test.mezo.org/address/0x637e22A1EBbca50EA2d34027c238317fD10003eB?tab=txs&ref=blog.mezo.org). Close your position whenever you want to receive your underlying Bitcoin collateral.
+* Loans are created onchain and [publicly verifiable 24/7](https://explorer.test.mezo.org/address/0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503?tab=txs&ref=blog.mezo.org). Close your position whenever you want to receive your underlying Bitcoin collateral.
 * MUSD borrow rates are fixed for the life of the loan, starting at 1-5%. Lock in your low rate, and don’t worry about the the market.
 
 This documentation provides details about the MUSD architecture, how it fits into the Mezo ecosystem, risks and mitigations, and guides through how to access MUSD. 

--- a/src/content/docs/docs/users/musd/mint-musd.md
+++ b/src/content/docs/docs/users/musd/mint-musd.md
@@ -17,7 +17,7 @@ Before you can get testnet MUSD, you must complete the following steps:
 - Get testnet BTC on Testnet. You can request testnet BTC in [Discord](https://discord.com/invite/mezo).
 - Add the MUSD token to your wallet. You can add the token using the UI on the Mezo Explorer. Click the **Add token to MetaMask** button next to the MUSD token address:
     - Mainnet: [0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186](https://explorer.mezo.org/token/0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186)
-    - Testnet: [0x637e22A1EBbca50EA2d34027c238317fD10003eB](https://explorer.test.mezo.org/token/0x637e22A1EBbca50EA2d34027c238317fD10003eB)
+    - Testnet: [0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503](https://explorer.test.mezo.org/token/0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503)
 
 ## Borrow and mint
 

--- a/src/content/docs/docs/users/resources/contracts-reference.md
+++ b/src/content/docs/docs/users/resources/contracts-reference.md
@@ -29,7 +29,7 @@ Some of the token contracts are `TransparentUpgradableProxy` contracts. Add the 
 ### MUSD tokens
 
 - Mainnet MUSD: [0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186](https://explorer.mezo.org/token/0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186)
-- Testnet MUSD: [0x637e22A1EBbca50EA2d34027c238317fD10003eB](https://explorer.test.mezo.org/token/0x637e22A1EBbca50EA2d34027c238317fD10003eB)
+- Testnet MUSD: [0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503](https://explorer.test.mezo.org/token/0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503)
 
 ### MUSD bridge
 


### PR DESCRIPTION
Looks like we reference an old MUSD testnet address in our docs. This PR updates it.

Reference discord thread that mentions a new address: https://discord.com/channels/1079490158639976609/1374287413991706709/1374293992325517372 