### PR TITLE
Changing Pyth addresses

### DIFF
--- a/src/content/docs/docs/developers/architecture/oracles/index.md
+++ b/src/content/docs/docs/developers/architecture/oracles/index.md
@@ -44,7 +44,7 @@ Supra is a cross-chain oracle network designed to power dApps across blockchain 
 The [Pyth Network](https://pyth.network/) is one of the largest first-party Oracle networks and delivers real-time data across several chains including Mezo. Pyth introduces an innovative low-latency [pull oracle design](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) where users can pull price updates onchain when needed. This enables everyone in the onchain environment to access data points efficiently. The Pyth network updates the prices every 400ms to make Pyth one of the fastest onchain oracles.
 
 Pyth's oracle contracts:
-- Mezo Mainnet: [0x2880aB155794e7179c9eE2e38200202908C17B43](https://explorer.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43)
-- Mezo Testnet: [0xA2aa501b19aff244D90cc15a4Cf739D2725B5729](https://explorer.test.mezo.org/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)
+- Mezo Mainnet (proxy): [0x2880aB155794e7179c9eE2e38200202908C17B43](https://explorer.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43)
+- Mezo Testnet (proxy): [0x2880aB155794e7179c9eE2e38200202908C17B43](https://explorer.test.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43)
 
 See the [Pyth Documentation](https://docs.pyth.network/home) to learn how to use Pyth in your dApp.

--- a/src/content/docs/docs/developers/getting-started/integrations-and-partners.md
+++ b/src/content/docs/docs/developers/getting-started/integrations-and-partners.md
@@ -30,8 +30,8 @@ Supra is a cross-chain oracle network designed to power dApps across blockchain 
 The [Pyth Network](https://pyth.network/) is one of the largest first-party Oracle networks and delivers real-time data across several chains including Mezo. Pyth introduces an innovative low-latency [pull oracle design](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) where users can pull price updates onchain when needed. This enables everyone in the onchain environment to access data points efficiently. The Pyth network updates the prices every 400ms to make Pyth one of the fastest onchain oracles.
 
 Pyth contracts:
-- Mezo Mainnet: [0x2880aB155794e7179c9eE2e38200202908C17B43](https://explorer.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43)
-- Mezo Testnet: [0xA2aa501b19aff244D90cc15a4Cf739D2725B5729](https://explorer.test.mezo.org/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729)
+- Mezo Mainnet (proxy): [0x2880aB155794e7179c9eE2e38200202908C17B43](https://explorer.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43)
+- Mezo Testnet (proxy): [0x2880aB155794e7179c9eE2e38200202908C17B43](https://explorer.test.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43)
 
 See the [Pyth Documentation](https://docs.pyth.network/home) to learn how to use Pyth in your dApp.
 


### PR DESCRIPTION
Both mainnet and testnet Pyth contract addresses are the same for proxy and initial implementation. Implementation address was used for testnet instead of a proxy address.