### PR TITLE
Updating Boar legacy RPC urls

### DIFF
--- a/src/content/docs/docs/developers/getting-started/index.md
+++ b/src/content/docs/docs/developers/getting-started/index.md
@@ -44,8 +44,8 @@ We value your input as you build on Mezo. Please use the resources below for sup
 
 * Public JSON RPC Endpoints:
   * Boar:
-    * HTTPS: `https://jsonrpc-mezo.boar.network`
-    * WSS: `wss://jsonrpcws-mezo.boar.network`
+    * HTTPS: `https://rpc-http.mezo.boar.network`
+    * WSS: `wss://rpc-ws.mezo.boar.network`
     * For higher rate limits get your free API key at [boar.network/mezo](https://boar.network/mezo). Enterprise plan available - contact [hello@boar.network](hello@boar.network) to get started.
   * Imperator:
     * HTTPS: `https://rpc_evm-mezo.imperator.co`

--- a/src/content/docs/docs/users/getting-started/connect.md
+++ b/src/content/docs/docs/users/getting-started/connect.md
@@ -16,8 +16,8 @@ If Chainlist does not work, add the network manually using the network details b
 
 * Public JSON RPC Endpoints:
   * Boar:
-    * HTTPS: `https://jsonrpc-mezo.boar.network`
-    * WSS: `wss://jsonrpcws-mezo.boar.network`
+    * HTTPS: `https://rpc-http.mezo.boar.network`
+    * WSS: `wss://rpc-ws.mezo.boar.network`
   * Imperator:
     * HTTPS: `https://rpc_evm-mezo.imperator.co`
     * WSS: `wss://ws_evm-mezo.imperator.co`


### PR DESCRIPTION
Boar has changed their public free RPC urls. This PR updates them to
```
https://rpc-http.mezo.boar.network
wss://rpc-ws.mezo.boar.network
```