### PR TITLE
Fix mats sidebar label capitalization

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -154,11 +154,11 @@ export default defineConfig({
                         label: 'MUSD',
                         collapsed: true,
                         items: [
-                              'docs/users/musd',
-                              'docs/users/musd/concepts',
-                              'docs/users/musd/mint-musd',
-                              'docs/users/musd/fees',
                               'docs/users/musd/architecture-and-terminology',
+                              'docs/users/musd/concepts',
+                              'docs/users/musd/fees',
+                              'docs/users/musd',
+                              'docs/users/musd/mint-musd',
                               'docs/users/musd/liquidation-mechanics',
                               'docs/users/musd/musd-bridge',
                               'docs/users/musd/risks'

--- a/scripts/process-gitbook.js
+++ b/scripts/process-gitbook.js
@@ -384,6 +384,7 @@ class GitbookProcessor {
       .replace(/[-_]/g, ' ')                    // Replace dashes and underscores with spaces
       .replace(/\b\w/g, l => l.toUpperCase())   // Capitalize first letter of each word
       .replace(/\bmusd\b/gi, 'MUSD')            // Special case for MUSD
+      .replace(/\bmats\b/gi, 'mats')            // Special case for mats (keep lowercase)
       .replace(/\bbtc\b/gi, 'BTC')              // Special case for BTC
       .replace(/\bstbtc\b/gi, 'stBTC')          // Special case for stBTC
       .replace(/\btbtc\b/gi, 'tBTC')            // Special case for tBTC


### PR DESCRIPTION
- Change sidebar label from 'Mats' to 'mats' in astro.config.mjs
- Add special case in humanizeTitle function to keep 'mats' lowercase
- Ensures consistent lowercase branding for mats section