### PR TITLE
Fix MUSD section order in sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -154,14 +154,14 @@ export default defineConfig({
                         label: 'MUSD',
                         collapsed: true,
                         items: [
-                              'docs/users/musd/architecture-and-terminology',
-                              'docs/users/musd/concepts',
-                              'docs/users/musd/fees',
                               'docs/users/musd',
                               'docs/users/musd/mint-musd',
+                              'docs/users/musd/fees',
+                              'docs/users/musd/architecture-and-terminology',
                               'docs/users/musd/liquidation-mechanics',
                               'docs/users/musd/musd-bridge',
-                              'docs/users/musd/risks'
+                              'docs/users/musd/risks',
+                              'docs/users/musd/concepts'
                         ]
                   },
                   {


### PR DESCRIPTION
- Restore correct order: Overview, Mint, Fees, Architecture, Liquidations, Bridge, Risks, Concepts