### PR TITLE
docs: clarify poke behavior and epoch vote persistence

### DIFF
--- a/src/content/docs/docs/users/mezo-earn/lock/vemezo/boost-mechanism.mdx
+++ b/src/content/docs/docs/users/mezo-earn/lock/vemezo/boost-mechanism.mdx
@@ -56,8 +56,8 @@ Every veBTC NFT has its own veBTC boost gauge. veMEZO holders vote on these gaug
 
 1. **veBTC holder creates a position** — A veBTC NFT is minted with an associated boost gauge
 2. **veMEZO holders vote** — They allocate veMEZO weight to veBTC gauges
-3. **Boost is calculated** — The veBTC position's boost depends on total veMEZO votes it receives
-4. **Position is "poked"** — The veBTC holder triggers a transaction to apply the new boost
+3. **Boost is calculated and applied** — The veBTC position's boost depends on total veMEZO votes it receives. After pairing, the veBTC owner must update the veBTC's voting power — this is the last action of the Pair & Boost stepper in the dApp.
+4. **Position is "poked" to update existing votes** — If the veBTC already had votes allocated to gauges, the owner must call the Poke function to refresh those votes so they reflect the updated (boosted) voting power. The 'Poke' button is visible on the veBTC's details on the [Vote page](https://mezo.org/vote).
 
 ### Why This Creates a Market
 

--- a/src/content/docs/docs/users/mezo-earn/vote/claiming-fees-emissions.md
+++ b/src/content/docs/docs/users/mezo-earn/vote/claiming-fees-emissions.md
@@ -102,6 +102,8 @@ veMEZO max lock is 4 years (compared to 28 days for veBTC). The longer lock refl
 
 Poke is a transaction that refreshes your position's voting power to reflect its current state. Without poking, changes to your boost don't take effect.
 
+If your veBTC already had votes allocated and you then pair & boost it with veMEZO, you need to poke the position so that your existing votes are updated to reflect the new boosted voting power. The 'Poke' button is available on your veBTC's details on the [Vote page](https://mezo.org/vote).
+
 **When do I need to poke?**
 
 Poke after:

--- a/src/content/docs/docs/users/mezo-earn/vote/index.mdx
+++ b/src/content/docs/docs/users/mezo-earn/vote/index.mdx
@@ -69,7 +69,7 @@ Mezo operates in 7-day epochs starting Thursday at 00:00 UTC. Each epoch is a fr
 6. Repeat
 </Steps>
 
-> **Critical:** Votes don't carry over. If you don't vote in a given epoch, you forfeit your share of fees and incentives for that week.
+> **Note:** Your vote allocations remain recorded across epochs until you reset or change them. As long as your votes are still in place, you'll continue to earn your share of trading fees and incentives each epoch based on your current allocations. Poke is used to refresh your voting power — for example, pushing it up after pairing with veMEZO, or letting others push it down as it decays.
 
 ### Epoch Alignment
 


### PR DESCRIPTION
## Summary
- Clarify in the Vote FAQs that **Poke** is required after pair & boost when the veBTC already had votes allocated, with a pointer to the Poke button on the Vote page
- Expand steps 3 & 4 of the Boost Mechanism "How It Works" section to spell out that the veBTC owner must update voting power (last action of the Pair & Boost stepper) and call Poke to refresh existing votes
- Correct the weekly epoch callout in the Voting Overview: vote allocations persist across epochs and continue earning trading fees and incentives until reset; Poke is about refreshing voting power, not a prerequisite for earning

Driven by Discord feedback from Michalina and Antonio about confusing/inaccurate language around Poke and epoch vote carryover.

## Test plan
- [ ] Verify the three updated pages render correctly in local dev
- [ ] Confirm the Vote page link resolves
- [ ] Spot-check anchors `#poke`, `#how-it-works`, and `#the-weekly-epoch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)