### PR TITLE
docs: update bridges page to reflect Base network support

### DIFF
--- a/src/content/docs/docs/users/mainnet/bridges.mdx
+++ b/src/content/docs/docs/users/mainnet/bridges.mdx
@@ -36,7 +36,7 @@ For BTC wallets, you can sign in with UniSat, OKX, and Xverse. Use the following
 
 # Withdrawals 
 
-## Moving Your Assets from Mezo to Ethereum or Bitcoin
+## Moving Your Assets from Mezo to Other Networks
 
 *Last updated: November 14, 2025*
 
@@ -54,12 +54,12 @@ This guide explains how to bridge your assets out of Mezo back to the Ethereum o
 | **mERC-20 tokens** | Bitcoin | Not available | ERC-20 tokens can't be sent to Bitcoin |
 
 :::note[Key Points]
-- You can only bridge to Ethereum or Bitcoin mainnet.
+- You can bridge your assets between Mezo and Bitcoin mainnet, Ethereum, and Base network.
 - BTC can go to Ethereum (as tBTC) or to Bitcoin (as native BTC).
 - Tokens like USDC or T (represented as m-tokens on Mezo) can only go back to Ethereum.
-- MEZO tokens can be bridged to Ethereum, Base, BSC, and Solana via [Wormhole NTT](/docs/users/mezo/mezo-bridge).
+- MEZO and MUSD can be bridged to and from Base network via [Wormhole NTT](/docs/users/mezo/mezo-bridge).
+- MEZO tokens can also be bridged to BSC and Solana via [Wormhole NTT](/docs/users/mezo/mezo-bridge).
 - Bitcoin Taproot addresses (starting with `bc1p`) aren't supported yet.
-- Layer 2 networks and other chains aren't available as destinations.
 :::
 
 ## How to Bridge Out
@@ -249,8 +249,8 @@ A: No, once submitted, bridge transactions cannot be cancelled. Your Mezo tokens
 **Q: How long does bridging take?**
 A: Most bridge transactions complete within 30-60 minutes, depending on network conditions and validator attestation speed.
 
-**Q: Can I bridge to Arbitrum, Optimism, or other L2s?**
-A: Currently, only Ethereum mainnet and Bitcoin mainnet are supported destinations. L2 support may be added in the future.
+**Q: What networks can I bridge to?**
+A: Assets can be bridged between Ethereum, Mezo, Base, and Bitcoin. Additional network support will be added in the future.
 
 **Q: My native Bitcoin deposit hasn't appeared yet. How do I check its status?**
 A: See [Track Your Native Bitcoin Deposit](/docs/users/mainnet/track-your-native-bitcoin-deposit) for a step-by-step guide on using tBTCScan to verify your deposit status.


### PR DESCRIPTION
## Summary
- Updated section heading from "Moving Your Assets from Mezo to Ethereum or Bitcoin" to "Moving Your Assets from Mezo to Other Networks"
- Replaced key points box to include Base network as a supported bridging destination (via Wormhole NTT for MEZO and MUSD)
- Updated FAQ from "Can I bridge to Arbitrum, Optimism, or other L2s?" to "What networks can I bridge to?" with current network list

## Test plan
- [ ] Verify the bridges page renders correctly at `/docs/users/mainnet/bridges`
- [ ] Confirm anchor link `#moving-your-assets-from-mezo-to-other-networks` works (old anchor may need redirect check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)