### PR TITLE
docs: remove manual poke references and add MEZO to gas station

### DIFF
--- a/src/content/docs/docs/users/getting-started/get-gas.mdx
+++ b/src/content/docs/docs/users/getting-started/get-gas.mdx
@@ -1,14 +1,14 @@
 ---
 title: Gasless Swaps
 description: >-
-  Learn how to use the Get Gas feature to swap a small amount of MUSD for BTC
+  Learn how to use the Get Gas feature to swap a small amount of MUSD or MEZO for BTC
   gas when your balance is low.
 topic: users
 ---
 
 import { Steps } from '@astrojs/starlight/components';
 
-The **Get Gas** feature lets you acquire a small amount of BTC to cover transaction (gas) fees on Mezo — even if you have no BTC in your wallet. It works by performing a **gasless swap**, exchanging a small amount of MUSD for exactly **0.0001 BTC**, enough to cover multiple transactions on the network.
+The **Get Gas** feature lets you acquire a small amount of BTC to cover transaction (gas) fees on Mezo — even if you have no BTC in your wallet. It works by performing a **gasless swap**, exchanging a small amount of MUSD or MEZO for exactly **0.0001 BTC**, enough to cover multiple transactions on the network.
 
 Because the swap is gasless (powered by meta-transactions), you don't need any existing BTC to use it.
 
@@ -18,7 +18,7 @@ A **"Get Gas"** button automatically appears in the Mezo app when your wallet's 
 
 ## Supported Tokens
 
-Currently, **MUSD** is the supported token for Get Gas swaps. Additional tokens may be added in the future as pool liquidity grows.
+The supported tokens for Get Gas swaps are **MUSD** and **MEZO**. This means users arriving on the chain with just MEZO can get a free swap into BTC for gas without needing to bridge additional assets.
 
 ## How to Get Gas
 
@@ -30,11 +30,11 @@ Currently, **MUSD** is the supported token for Get Gas swaps. Additional tokens 
 
 2. **Select a token**
 
-   Select MUSD as your source token. The modal will display the estimated cost for the swap.
+   Select MUSD or MEZO as your source token. The modal will display the estimated cost for the swap.
 
 3. **Review the quote**
 
-   The app quotes the amount of MUSD needed to receive exactly **0.0001 BTC**. The output amount is fixed so you always get a predictable gas amount regardless of token price.
+   The app quotes the amount of MUSD or MEZO needed to receive exactly **0.0001 BTC**. The output amount is fixed so you always get a predictable gas amount regardless of token price.
 
 4. **Confirm the swap**
 
@@ -58,17 +58,17 @@ The Get Gas feature uses **meta-transactions** to execute the swap without requi
 2. **Relay**: A backend relay service submits the swap transaction on your behalf, covering the gas cost.
 3. **Swap**: The transaction executes on-chain, swapping your token for **0.0001 BTC**, which is deposited directly into your wallet.
 
-This design means you can always get gas as long as you hold MUSD — no BTC needed to get started.
+This design means you can always get gas as long as you hold MUSD or MEZO — no BTC needed to get started.
 
 ## Key Details
 
 | Detail | Value |
 |---|---|
 | **Output amount** | 0.0001 BTC (fixed) |
-| **Eligible tokens** | MUSD |
+| **Eligible tokens** | MUSD, MEZO |
 | **Gas required** | None (gasless via meta-transactions) |
 | **Trigger** | BTC balance below 0.000001 BTC |
 
 :::note
-The cost in MUSD will vary based on current pool prices. The quote shown in the modal reflects the real-time rate at the time of the swap.
+The cost in MUSD or MEZO will vary based on current pool prices. The quote shown in the modal reflects the real-time rate at the time of the swap.
 :::

--- a/src/content/docs/docs/users/mezo-earn/lock/vemezo/boost-mechanism.mdx
+++ b/src/content/docs/docs/users/mezo-earn/lock/vemezo/boost-mechanism.mdx
@@ -56,8 +56,7 @@ Every veBTC NFT has its own veBTC boost gauge. veMEZO holders vote on these gaug
 
 1. **veBTC holder creates a position** — A veBTC NFT is minted with an associated boost gauge
 2. **veMEZO holders vote** — They allocate veMEZO weight to veBTC gauges
-3. **Boost is calculated and applied** — The veBTC position's boost depends on total veMEZO votes it receives. After pairing, the veBTC owner must update the veBTC's voting power — this is the last action of the Pair & Boost stepper in the dApp.
-4. **Position is "poked" to update existing votes** — If the veBTC already had votes allocated to gauges, the owner must call the Poke function to refresh those votes so they reflect the updated (boosted) voting power. The 'Poke' button is visible on the veBTC's details on the [Vote page](https://mezo.org/vote).
+3. **Boost is calculated and applied** — The veBTC position's boost depends on total veMEZO votes it receives. The Pair & Boost stepper in the dApp handles updating the veBTC's voting power and refreshing any existing votes automatically.
 
 ### Why This Creates a Market
 

--- a/src/content/docs/docs/users/mezo-earn/vote/claiming-fees-emissions.md
+++ b/src/content/docs/docs/users/mezo-earn/vote/claiming-fees-emissions.md
@@ -102,8 +102,6 @@ veMEZO max lock is 4 years (compared to 28 days for veBTC). The longer lock refl
 
 Poke is a transaction that refreshes your position's voting power to reflect its current state. Without poking, changes to your boost don't take effect.
 
-If your veBTC already had votes allocated and you then pair & boost it with veMEZO, you need to poke the position so that your existing votes are updated to reflect the new boosted voting power. The 'Poke' button is available on your veBTC's details on the [Vote page](https://mezo.org/vote).
-
 **When do I need to poke?**
 
 Poke after:


### PR DESCRIPTION
## Summary
- Removes the manual poke instruction from the Pair & Boost flow since poke is now incorporated into the stepper automatically
- Removes the standalone poke paragraph from the claiming-fees-emissions page (rest of Poke section preserved for other use cases)
- Adds MEZO as a supported token for Get Gas swaps alongside MUSD, so users arriving on-chain with just MEZO can swap for BTC gas

## Test plan
- [ ] Verify boost-mechanism page no longer references manual poke step
- [ ] Verify claiming-fees-emissions Poke section still covers general poke scenarios
- [ ] Verify Get Gas page reflects both MUSD and MEZO as eligible tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)