### PR TITLE
docs: correct Recovery Mode liquidation behavior for MUSD

### DIFF
--- a/src/content/docs/docs/users/musd/liquidation-mechanics.md
+++ b/src/content/docs/docs/users/musd/liquidation-mechanics.md
@@ -99,13 +99,14 @@ Important Note: The current user interface may not show your available surplus. 
 ## What is Recovery Mode?
 
 :::note
-Recovery Mode is a temporary safety state that activates if the entire MUSD system's total collateral ratio drops below 150%. It is a special system state with stricter liquidation rules.
+Recovery Mode is a temporary safety state that activates if the entire MUSD system's total collateral ratio (TCR) drops below 150%. It is a special system state with stricter borrowing rules.
 :::
 
 During Recovery Mode:
-- The minimum collateral ratio for liquidations increases from 110% to 150%.
-- This means loans with ratios below 150% can be liquidated.
-- The system encourages users to add collateral or repay debt to improve its overall health.
+- **Liquidations are not affected.** The liquidation threshold remains at 110% — the same as in Normal Mode. Unlike Liquity v1, MUSD does not expand liquidations to higher collateral ratios during Recovery Mode.
+- New loans cannot be opened below 150% collateral ratio.
+- Refinancing is blocked.
+- The system encourages users to add collateral or repay debt to restore the TCR above 150%.
 
 ---
 
@@ -116,7 +117,7 @@ The best defense against both liquidation and redemption is maintaining a high c
 :::
 
 ### To Avoid Liquidation:
-- Maintain a healthy buffer. Aim for a collateral ratio well above 150% to be safe from market volatility and Recovery Mode.
+- Maintain a healthy buffer. Aim for a collateral ratio well above 110% to stay safe from market volatility. A ratio above 150% also ensures you can borrow and refinance freely even if the system enters Recovery Mode.
 - Monitor your loan's health regularly, especially if the BTC price is dropping.
 - Be proactive: Add more collateral or repay some of your MUSD debt if your ratio gets too low.
 

--- a/src/content/docs/docs/users/resources/glossary.md
+++ b/src/content/docs/docs/users/resources/glossary.md
@@ -138,7 +138,7 @@ Rewards posted on gauges to attract votes. Protocols or users deposit incentives
 
 ## Liquidation
 
-The forced closure of an undercollateralized [trove](#trove). A trove can be liquidated when its [ICR](#collateralization-ratio-icr) falls below 110% (or 150% during [Recovery Mode](#recovery-mode)). The [Stability Pool](#stability-pool) absorbs the debt, and the liquidated collateral is distributed to Stability Pool depositors. See [Liquidations & Redemptions](/docs/users/musd/liquidation-mechanics).
+The forced closure of an undercollateralized [trove](#trove). A trove can be liquidated when its [ICR](#collateralization-ratio-icr) falls below 110%. The liquidation threshold remains at 110% even during [Recovery Mode](#recovery-mode). The [Stability Pool](#stability-pool) absorbs the debt, and the liquidated collateral is distributed to Stability Pool depositors. See [Liquidations & Redemptions](/docs/users/musd/liquidation-mechanics).
 
 ## Liquidity Pool
 
@@ -250,7 +250,7 @@ Anti-dilution distributions to veMEZO holders from weekly MEZO emissions. When t
 
 ## Recovery Mode
 
-A temporary safety state that activates when the system-wide Total Collateralization Ratio (TCR) falls below the [CCR](#critical-collateralization-ratio-ccr) of 150%. During Recovery Mode, the liquidation threshold increases from 110% to 150%, new loans cannot be opened below 150%, and refinancing is blocked. See [Liquidations & Redemptions](/docs/users/musd/liquidation-mechanics).
+A temporary safety state that activates when the system-wide Total Collateralization Ratio (TCR) falls below the [CCR](#critical-collateralization-ratio-ccr) of 150%. During Recovery Mode, the liquidation threshold remains at 110% (unlike Liquity v1, MUSD does not expand liquidations during Recovery Mode). However, new loans cannot be opened below 150%, and refinancing is blocked. See [Liquidations & Redemptions](/docs/users/musd/liquidation-mechanics).
 
 ## Redemption
 


### PR DESCRIPTION
## Summary
- **Recovery Mode in MUSD does not expand liquidations to 150%.** The docs incorrectly described Liquity v1 behavior where the liquidation threshold rises from 110% to 150% during Recovery Mode. MUSD removed this mechanic — liquidations always remain at 110%.
- Recovery Mode only restricts new borrowing (must be above 150% CR) and blocks refinancing.
- Fixed the liquidation-mechanics page, glossary Liquidation entry, and glossary Recovery Mode entry.

## Context
Flagged by community members in Discord. Confirmed by the developer docs (`developers/musd/index.md`) which already state: "No Special Recovery Mode Liquidations."

## Files changed
- `src/content/docs/docs/users/musd/liquidation-mechanics.md` — Rewrote Recovery Mode section; updated "To Avoid Liquidation" tip
- `src/content/docs/docs/users/resources/glossary.md` — Fixed Liquidation and Recovery Mode definitions

## Test plan
- [ ] Review Recovery Mode section on the liquidation-mechanics page
- [ ] Review glossary entries for Liquidation and Recovery Mode
- [ ] Confirm with team that 110% liquidation-only behavior is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)