### PR TITLE
docs: update Boar RPC endpoints to new URLs

### DIFF
--- a/src/content/docs/docs/developers/getting-started/configure-environment.md
+++ b/src/content/docs/docs/developers/getting-started/configure-environment.md
@@ -31,7 +31,7 @@ For advanced chain configuration and network parameters, see the [Chains Configu
 
 | Provider | HTTPS | WSS |
 |----------|-------|-----|
-| Boar | `https://rpc-http.mezo.boar.network` | `wss://rpc-ws.mezo.boar.network` |
+| Boar | `https://mezo-mainnet.boar.network` | `wss://mezo-mainnet.boar.network` |
 | Imperator | `https://rpc_evm-mezo.imperator.co` | `wss://ws_evm-mezo.imperator.co` |
 | Validation Cloud | `https://mainnet.mezo.public.validationcloud.io` | `wss://mainnet.mezo.public.validationcloud.io` |
 | dRPC NodeCloud | `https://mezo.drpc.org` | `wss://mezo.drpc.org` |
@@ -45,7 +45,7 @@ module.exports = {
   defaultNetwork: "mezomainnet",
   networks: {
     mezomainnet: {
-      url: "https://rpc-http.mezo.boar.network",
+      url: "https://mezo-mainnet.boar.network",
       chainId: 31612,
       accounts: ["YOUR_PRIVATE_WALLET_KEY"] // Use environment variables for security
     }
@@ -70,7 +70,7 @@ To configure a Foundry project for Mezo Mainnet, set the following in your `foun
 ```toml
 [profile.default]
 chain_id = 31612
-eth_rpc_url = "https://rpc-http.mezo.boar.network"
+eth_rpc_url = "https://mezo-mainnet.boar.network"
 evm_version = 'london'
 ```
 

--- a/src/content/docs/docs/developers/getting-started/index.mdx
+++ b/src/content/docs/docs/developers/getting-started/index.mdx
@@ -195,7 +195,7 @@ For production deployments, use the following Mainnet details. It is recommended
 
 | Provider | HTTPS Endpoint | WSS Endpoint | Notes |
 | --- | --- | --- | --- |
-| Boar | `https://rpc-http.mezo.boar.network` | `wss://rpc-ws.mezo.boar.network` |
+| Boar | `https://mezo-mainnet.boar.network` | `wss://mezo-mainnet.boar.network` |
 | Imperator | `https://rpc_evm-mezo.imperator.co` | `wss://ws_evm-mezo.imperator.co` |
 | Validation Cloud | `https://mainnet.mezo.public.validationcloud.io` | `wss://mainnet.mezo.public.validationcloud.io` |
 | dRPC NodeCloud | `https://mezo.drpc.org` | `wss://mezo.drpc.org` |

--- a/src/content/docs/docs/users/getting-started/connect.md
+++ b/src/content/docs/docs/users/getting-started/connect.md
@@ -18,7 +18,7 @@ If Chainlist does not work, add the network manually using the network details b
 
 | Provider | HTTPS | WSS |
 |----------|-------|-----|
-| Boar | `https://rpc-http.mezo.boar.network` | `wss://rpc-ws.mezo.boar.network` |
+| Boar | `https://mezo-mainnet.boar.network` | `wss://mezo-mainnet.boar.network` |
 | Imperator | `https://rpc_evm-mezo.imperator.co` | `wss://ws_evm-mezo.imperator.co` |
 | Validation Cloud | `https://mainnet.mezo.public.validationcloud.io` | `wss://mainnet.mezo.public.validationcloud.io` |
 


### PR DESCRIPTION
- Update Boar RPC HTTPS endpoint from `rpc-http.mezo.boar.network` to `mezo-mainnet.boar.network`
- Update Boar RPC WSS endpoint from `rpc-ws.mezo.boar.network` to `mezo-mainnet.boar.network`
- Applied across developer getting-started guide, environment configuration, and user connect docs

The change already done for Chainlist https://github.com/ethereum-lists/chains/pull/8362