### PR TITLE
docs: direct late vault withdrawals to Mellow

### DIFF
--- a/src/content/docs/docs/users/mezo-earn/vaults/vault-notices.md
+++ b/src/content/docs/docs/users/mezo-earn/vaults/vault-notices.md
@@ -43,7 +43,7 @@ If you have a position in the vault, start your withdrawal by **July 31, 2026**.
 2. Select **Withdraw** and follow the prompts for your position.
 3. Confirm the transaction and allow approximately 48 hours for the withdrawal queue to process.
 
-After July 31, 2026, the Stablecoin Vault will no longer appear in the app. If you miss the withdrawal window, [contact Mezo Support](/docs/users/resources/support) for help with a manual withdrawal.
+After July 31, 2026, the Stablecoin Vault will no longer appear in the app. Mellow will manage the remaining funds and process late withdrawals. If you miss the withdrawal window, [open a support ticket in Mellow's Discord](https://discord.com/invite/mellow).
 
 ## Where to put stablecoins next
 


### PR DESCRIPTION
## Summary

- clarify that Mellow manages remaining Stablecoin Vault funds after the withdrawal window
- direct users who need a late withdrawal to open a support ticket in Mellow's Discord

## Why

The existing notice incorrectly directs late-withdrawal requests to Mezo Support. After the 30-day withdrawal period, Mellow owns the support path for the remaining vault funds.

## User impact

Users who miss the July 31, 2026 withdrawal window will be sent to the team that can process their late withdrawal.

## Validation

- confirmed `https://discord.com/invite/mellow` responds successfully
- ran Prettier on the updated page
- ran `git diff --check`
