### PR TITLE
docs: add USDC Savings Vault page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -275,7 +275,8 @@ export default defineConfig({
                                     items: [
                                           'docs/users/mezo-earn/vaults',
                                           'docs/users/mezo-earn/vaults/vault-notices',
-                                          'docs/users/mezo-earn/vaults/musd-savings-vault'
+                                          'docs/users/mezo-earn/vaults/musd-savings-vault',
+                                          'docs/users/mezo-earn/vaults/usdc-savings-vault'
                                     ]
                               }
                         ]

--- a/src/content/docs/docs/SUMMARY.md
+++ b/src/content/docs/docs/SUMMARY.md
@@ -64,6 +64,7 @@ topic: users
       * [Vaults Overview](users/mezo-earn/vaults/index.md)
       * [Vault Notices](users/mezo-earn/vaults/vault-notices.md)
       * [MUSD Savings Vault](users/mezo-earn/vaults/musd-savings-vault.md)
+      * [USDC Savings Vault](users/mezo-earn/vaults/usdc-savings-vault.md)
   * [passport](users/passport/README.md)
     * [Send Assets](users/passport/send-assets.md)
     * [Mezo ID](users/passport/mezo-id.md)

--- a/src/content/docs/docs/users/borrow/how-to-borrow-musdc.mdx
+++ b/src/content/docs/docs/users/borrow/how-to-borrow-musdc.mdx
@@ -64,15 +64,7 @@ Additionally, MUSD has a redemption mechanism that helps hold its \$1 peg, which
 
 Once you have an active loan, you can manage it through the Mezo App. From the Borrow dashboard, you can track how much mUSDC you owe, how much BTC is locked as collateral, your current LTV, your liquidation price, your current APR, and your recent activity. You can also repay your mUSDC to close the loan — once repaid, your collateral becomes available again, and your closed position appears in your borrow history.
 
-## USDC Lending Vault
-
-The USDC Lending Vault gives investors direct exposure to a transparent market for BTC-backed credit.
-
-Every mUSDC loan on Mezo is funded by capital supplied through the USDC Lending Vault. Depositors provide mUSDC to the vault, which allocates that liquidity to borrowers using BTC as collateral. Interest paid by borrowers accrues to the vault and forms the underlying source of depositor yield.
-
-Loans are overcollateralized by BTC, and collateral balances, outstanding debt, interest rates, and position health are recorded onchain. Deposited assets are not rehypothecated. The return earned by the vault can be traced directly to interest paid by borrowers.
-
-There is no minimum deposit and no protocol fee to enter or exit the vault. Withdrawals may be requested at any time, subject to the amount of liquidity not currently deployed across active loans. As utilization rises, withdrawal liquidity may decline until borrowers repay debt or new capital enters the vault. Depositors may also stake their vault shares in the associated gauge to receive MEZO emissions.
+To supply mUSDC and earn yield from borrower interest, see the [USDC Savings Vault](/docs/users/mezo-earn/vaults/usdc-savings-vault).
 
 ## FAQs
 

--- a/src/content/docs/docs/users/mezo-earn/vaults/index.md
+++ b/src/content/docs/docs/users/mezo-earn/vaults/index.md
@@ -36,7 +36,7 @@ Visit [mezo.org/earn/vaults](https://mezo.org/earn/vaults) to explore available 
 
 ### Mezo Vaults
 
-Vaults built and managed by Mezo, such as the MUSD Savings Vault.
+Vaults built and managed by Mezo, such as the [MUSD Savings Vault](/docs/users/mezo-earn/vaults/musd-savings-vault) and [USDC Savings Vault](/docs/users/mezo-earn/vaults/usdc-savings-vault).
 
 ### External Vaults
 

--- a/src/content/docs/docs/users/mezo-earn/vaults/usdc-savings-vault.md
+++ b/src/content/docs/docs/users/mezo-earn/vaults/usdc-savings-vault.md
@@ -1,0 +1,13 @@
+---
+title: USDC Savings Vault
+description: Earn yield by supplying mUSDC to the BTC-backed credit market on Mezo
+topic: users
+---
+
+The USDC Lending Vault gives investors direct exposure to a transparent market for BTC-backed credit.
+
+Every mUSDC loan on Mezo is funded by capital supplied through the USDC Lending Vault. Depositors provide mUSDC to the vault, which allocates that liquidity to borrowers using BTC as collateral. Interest paid by borrowers accrues to the vault and forms the underlying source of depositor yield.
+
+Loans are overcollateralized by BTC, and collateral balances, outstanding debt, interest rates, and position health are recorded onchain. Deposited assets are not rehypothecated. The return earned by the vault can be traced directly to interest paid by borrowers.
+
+There is no minimum deposit and no protocol fee to enter or exit the vault. Withdrawals may be requested at any time, subject to the amount of liquidity not currently deployed across active loans. As utilization rises, withdrawal liquidity may decline until borrowers repay debt or new capital enters the vault. Depositors may also stake their vault shares in the associated gauge to receive MEZO emissions.


### PR DESCRIPTION
## Summary
- Move USDC Lending Vault content out of the mUSDC borrow guide into a dedicated **USDC Savings Vault** page under Vaults
- Wire the new page into the sidebar, SUMMARY, and vaults overview
- Leave a link from the borrow guide to the new vault page

## Test plan
- [x] Confirm `/docs/users/mezo-earn/vaults/usdc-savings-vault` renders
- [x] Confirm Vaults sidebar shows USDC Savings Vault
- [x] Confirm How to Borrow mUSDC no longer includes the vault section and links to the new page


Made with [Cursor](https://cursor.com)