### PR TITLE
docs: keep Vaults sidebar expanded by default

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -271,7 +271,7 @@ export default defineConfig({
                               },
                               {
                                     label: 'Vaults',
-                                    collapsed: true,
+                                    collapsed: false,
                                     items: [
                                           'docs/users/mezo-earn/vaults',
                                           'docs/users/mezo-earn/vaults/vault-notices',


### PR DESCRIPTION
## Summary
- Set the Vaults sidebar group to `collapsed: false` so vault pages (including USDC Lending Vault) stay visible whenever Mezo Earn is open
- Avoids the Vaults group only expanding after navigating into a child page like MUSD Savings Vault

## Test plan
- [ ] Open Mezo Earn in the docs sidebar and confirm Vaults children are visible without an extra click
- [ ] Confirm Vaults Overview, Vault Notices, MUSD Savings Vault, and USDC Lending Vault all appear as siblings under Vaults


Made with [Cursor](https://cursor.com)