### PR TITLE
docs: replace P2P with MCLB in validator list

### DIFF
--- a/src/content/docs/docs/developers/mezo-nodes/validators.md
+++ b/src/content/docs/docs/developers/mezo-nodes/validators.md
@@ -123,14 +123,14 @@ topic: developers
       </td>
     </tr>
     <tr>
+      <td>MCLB</td>
+      <td><span data-option="kho2A8rahGbq">Running</span></td>
+      <td><a href="https://mclb.org/">https://mclb.org/</a></td>
+    </tr>
+    <tr>
       <td>Node.Monster</td>
       <td><span data-option="kho2A8rahGbq">Running</span></td>
       <td><a href="https://www.node.monster/">https://www.node.monster/</a></td>
-    </tr>
-    <tr>
-      <td>P2P</td>
-      <td><span data-option="kho2A8rahGbq">Running</span></td>
-      <td><a href="https://www.p2p.org/">https://www.p2p.org/</a></td>
     </tr>
     <tr>
       <td>SenseiNode</td>


### PR DESCRIPTION
Removes P2P validator (p2p.org) and adds MCLB (mclb.org) as an active validator, placed in alphabetical order.