### PR TITLE
docs: update community projects and token references

### DIFF
--- a/src/content/docs/docs/developers/mezo-nodes/validator-gauge.md
+++ b/src/content/docs/docs/developers/mezo-nodes/validator-gauge.md
@@ -14,10 +14,6 @@ Each validator has an associated gauge in the [ValidatorsVoter contract](https:/
 
 Each gauge has a single beneficiary address that is authorized to claim rewards. By default, the beneficiary is the validator operator address registered in the [Proof of Authority (PoA) contract](https://explorer.mezo.org/address/0x7B7C000000000000000000000000000000000011?tab=read_contract#ca1e7819).
 
-:::note[No UI Yet]
-There is currently no dedicated UI for validator gauge operations. All actions described below — changing the beneficiary, voting, and claiming rewards — must be performed through the [Mezo block explorer](https://explorer.mezo.org) or via a custom script.
-:::
-
 :::note[Reward Release Schedule]
 Allocated epoch rewards are not immediately available for claim—they are gradually released over the epoch. For example, if rewards are allocated to a gauge at the beginning of epoch N, 100% of epoch N rewards will be available at the epoch's end.
 :::

--- a/src/content/docs/docs/users/integrations/community-projects.md
+++ b/src/content/docs/docs/users/integrations/community-projects.md
@@ -20,6 +20,17 @@ URL: [https://antwyr.com/](https://antwyr.com/)
 - Decode raw transaction calldata so you can inspect function names, parameters, and token amounts before signing.
 - Generate a live heatmap that visualizes currency volumes transacted per block on the Mezo network in real time.
 
+## Aurove
+
+[Aurove](https://www.aurove.xyz/) is a liquid ve-yield layer for Mezo Earn that turns locked veBTC and veMEZO positions into liquid, composable assets while keeping them deployed in managed yield strategies.
+
+URL: [https://www.aurove.xyz/](https://www.aurove.xyz/)
+
+- Deposit BTC or MEZO, or an existing veBTC or veMEZO position, into a managed tranche and receive a liquid tokenized claim.
+- Swap supported assets and veNFT positions, or provide concentrated liquidity to Aurove pools and collect fees.
+- Claim tranche and gauge rewards, redeem during weekly settlement windows, and earn points through Aurove Academy.
+- Aurove currently operates on Mezo Testnet. See the [Aurove docs](https://www.aurove.xyz/docs/introduction/what-is-aurove) and [Aurove on X](https://x.com/aurove_xyz) for product details and deployment updates.
+
 ## Matchbox
 
 [Matchbox](https://matchbox.markets) is a matching market that connects veBTC holders with veMEZO holders on Mezo, creating a marketplace for voting, incentives, and boost.
@@ -49,6 +60,16 @@ URL: [https://mezotools.cc/](https://mezotools.cc/)
 - Track system-level collateralization and monitor MUSD health metrics.
 - Review individual troves, redemptions, and liquidation activity.
 - Use it for higher-frequency monitoring beyond the core app views.
+
+## Range
+
+[Range](https://range.opturafi.com/) is an automated concentrated-liquidity rebalancing vault for Mezo's Uniswap V3-compatible DEX.
+
+URL: [https://range.opturafi.com/](https://range.opturafi.com/)
+
+- Deposit MUSD or BTC into an ERC-4626 vault to earn concentrated-liquidity fees without manually managing tick ranges.
+- Choose a range strategy that matches your risk appetite.
+- Track vault TVL, share price, the current tick range, and the complete rebalance history from the dashboard.
 
 ## veBoost Calculator
 

--- a/src/content/docs/docs/users/resources/contracts-reference.md
+++ b/src/content/docs/docs/users/resources/contracts-reference.md
@@ -25,6 +25,7 @@ Some of the token contracts are `TransparentUpgradableProxy` contracts. Add the 
 | mUSDT | USDT | [0xeB5a5d39dE4Ea42C2Aa6A57EcA2894376683bB8E](https://explorer.mezo.org/token/0xeB5a5d39dE4Ea42C2Aa6A57EcA2894376683bB8E) | [0xdAC17F958D2ee523a2206206994597C13D831ec7](https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7) |
 | mxSolvBTC | xSolvBTC | [0xdF708431162Ba247dDaE362D2c919e0fbAfcf9DE](https://explorer.mezo.org/address/0xdF708431162Ba247dDaE362D2c919e0fbAfcf9DE) | [0xd9D920AA40f578ab794426F5C90F6C731D159DEf](https://etherscan.io/address/0xd9D920AA40f578ab794426F5C90F6C731D159DEf) |
 | BTC | tBTC | [0x7b7C000000000000000000000000000000000000](https://explorer.mezo.org/address/0x7b7C000000000000000000000000000000000000) | [0x18084fbA666a33d37592fA2633fD49a74DD93a88](https://etherscan.io/address/0x18084fbA666a33d37592fA2633fD49a74DD93a88) |
+| sUSDat (Staked USDat) | sUSDat | [0xde402D7021f3F7F00be5D0Ab5C238B2bE1d2904F](https://explorer.mezo.org/address/0xde402D7021f3F7F00be5D0Ab5C238B2bE1d2904F) | [0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7](https://etherscan.io/address/0xD166337499E176bbC38a1FBd113Ab144e5bd2Df7) |
 | aMUSD | aMUSD | Not yet available on Mezo* | [0x52317a47585A6ACDfbD7a29B494c3E2baAE96aBc](https://etherscan.io/address/0x52317a47585A6ACDfbD7a29B494c3E2baAE96aBc) |
 
 :::note


### PR DESCRIPTION
## Summary

- remove the outdated “No UI Yet” validator gauge notice
- add Range and Aurove to the Community Projects page
- add the Mezo and Ethereum sUSDat contract addresses to the token reference

## Why

The validator gauge notice no longer reflects the available product experience, and the community and contract reference pages need to include the latest ecosystem projects and token deployment.

## User impact

Users can discover Range and Aurove from the Mezo documentation and verify the sUSDat contract addresses on both supported networks without relying on external lists.

## Validation

- `npm run build`
- `git diff --check`
